### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ let options = {
 UglifyPHP.minify("C:/web/file.php", options).then(function (source) {
   console.log(source);
 });
+
+// Synchronous API (Path or Source Code)
+let source = UglifyPHP.minifySync("C:/web/file.php", options);
+
+// Synchronous API (Source Code)
+source = UglifyPHP.minifyCode("<?php echo 'hi'; ?>", options);
 ```
 
 ## Example

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,7 @@ function isFileSync(aPath) {
 	},
 	"output": ""
 }*/
-function minifyPHP(synchronous, file_value, user_options) {
+function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 	// Options
 	let options_excludes = [];
 
@@ -183,7 +183,7 @@ function minifyPHP(synchronous, file_value, user_options) {
 	}
 
 	// Check if its a file path
-	if (isFileSync(file_value)) {
+	if (!definitely_code && isFileSync(file_value)) {
 		// Reads the file
 		return synchronous ? parseData(fs.readFileSync(file_value, 'utf8')) : new Promise(function(resolve, reject) {
 			fs.readFile(file_value, 'utf8', (err, file_data) => {
@@ -207,8 +207,11 @@ function minifyPHP(synchronous, file_value, user_options) {
 }
 
 module.exports.minify = function(file_value, user_options) {
-	return minifyPHP(false, file_value, user_options);
+	return minifyPHP(false, false, file_value, user_options);
 };
 module.exports.minifySync = function(file_value, user_options) {
-	return minifyPHP(true, file_value, user_options);
+	return minifyPHP(true, false, file_value, user_options);
+};
+module.exports.minifyCode = function(code, user_options) {
+	return minifyPHP(true, true, code, user_options);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,7 @@ function minifyPHP(synchronous, file_value, user_options) {
 				return new Promise(function(resolve, reject) {
 					fs.writeFile(options_output, new_source, function(err) {
 						if (err) reject('Error: Can’t Write to File');
-						resolve();
+						resolve(new_source);
 					});
 				});
 			}
@@ -187,11 +187,16 @@ function minifyPHP(synchronous, file_value, user_options) {
 		// Reads the file
 		return synchronous ? parseData(fs.readFileSync(file_value, 'utf8')) : new Promise(function(resolve, reject) {
 			fs.readFile(file_value, 'utf8', (err, file_data) => {
-				if (err) reject('Error: Can’t Read From the Source File or Disk');
+				if (err) {
+					reject('Error: Can’t Read From the Source File or Disk');
+					return;
+				}
 
 				// Check if its a .php file
-				if (path.extname(file_value) != ".php")
+				if (path.extname(file_value).toLowerCase() !== ".php") {
 					reject('Error: This is Not a PHP File');
+					return;
+				}
 
 				parseData(file_data).then(resolve, reject);
 			});

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 	let options_minify_remove_comments = true;
 
 	let options_output = "";
-	let options_create_if_not_exists = false;
+	let options_files_only = false;
 
 	if(user_options){
 		if (user_options.excludes && "indexOf" in user_options.excludes) options_excludes = user_options.excludes;
@@ -83,7 +83,7 @@ function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 			if(user_options.minify.propertyIsEnumerable("remove_comments")) options_minify_remove_comments = user_options.minify.remove_comments;
 		}
 		if (user_options.output) options_output = user_options.output;
-		if (user_options.create) options_create_if_not_exists = true;
+		if (user_options.filesOnly) options_files_only = true;
 	}
 	// Minify & Obsfuscate Function
 	function parseData(source_code) {
@@ -185,7 +185,7 @@ function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 	}
 
 	// Check if its a file path
-	if (!definitely_code && (options_create_if_not_exists || isFileSync(file_value))) {
+	if (!definitely_code && (options_files_only || isFileSync(file_value))) {
 		// Reads the file
 		return synchronous ? parseData(fs.readFileSync(file_value, 'utf8')) : new Promise(function(resolve, reject) {
 			fs.readFile(file_value, 'utf8', (err, file_data) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 	let options_minify_remove_comments = true;
 
 	let options_output = "";
+	let options_create_if_not_exists = false;
 
 	if(user_options){
 		if (user_options.excludes && "indexOf" in user_options.excludes) options_excludes = user_options.excludes;
@@ -82,6 +83,7 @@ function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 			if(user_options.minify.propertyIsEnumerable("remove_comments")) options_minify_remove_comments = user_options.minify.remove_comments;
 		}
 		if (user_options.output) options_output = user_options.output;
+		if (user_options.create) options_create_if_not_exists = true;
 	}
 	// Minify & Obsfuscate Function
 	function parseData(source_code) {
@@ -167,11 +169,11 @@ function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 		//  Finished
 		if(options_output){
 			if (synchronous) {
-				fs.writeFileSync(options_output, new_source);
+				fs.writeFileSync(options_output, new_source, { flag: "w+" });
 				return new_source;
 			} else {
 				return new Promise(function(resolve, reject) {
-					fs.writeFile(options_output, new_source, function(err) {
+					fs.writeFile(options_output, new_source, { flag: "w+" }, function(err) {
 						if (err) reject('Error: Can’t Write to File');
 						resolve(new_source);
 					});
@@ -183,7 +185,7 @@ function minifyPHP(synchronous, definitely_code, file_value, user_options) {
 	}
 
 	// Check if its a file path
-	if (!definitely_code && isFileSync(file_value)) {
+	if (!definitely_code && (options_create_if_not_exists || isFileSync(file_value))) {
 		// Reads the file
 		return synchronous ? parseData(fs.readFileSync(file_value, 'utf8')) : new Promise(function(resolve, reject) {
 			fs.readFile(file_value, 'utf8', (err, file_data) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const uniqid = require('uniqid');
 const fs = require('fs');
 const path = require('path');
 
-var MAX_PATH_LENGTH = 4096;
+let MAX_PATH_LENGTH = 4096;
 
 const parser = new engine({
 	parser: {extractDoc: true},
@@ -66,14 +66,14 @@ function isFileSync(aPath) {
 }*/
 function minifyPHP(synchronous, file_value, user_options) {
 	// Options
-	var options_excludes = [];
-	
-	var options_minify_replace_variables = true;
-	var options_minify_remove_whitespace = true;
-	var options_minify_remove_comments = true;
-	
-	var options_output = "";
-	
+	let options_excludes = [];
+
+	let options_minify_replace_variables = true;
+	let options_minify_remove_whitespace = true;
+	let options_minify_remove_comments = true;
+
+	let options_output = "";
+
 	if(user_options){
 		if (user_options.excludes && "indexOf" in user_options.excludes) options_excludes = user_options.excludes;
 		if (user_options.minify){
@@ -98,19 +98,19 @@ function minifyPHP(synchronous, file_value, user_options) {
 				return;
 			}
 
-			if (token[0] == 'T_VARIABLE' && options_excludes.indexOf(token[1]) < 0) {
+			if (token[0] === 'T_VARIABLE' && options_excludes.indexOf(token[1]) < 0) {
 				if(!variables[token[1]]) variables[token[1]] = uniqid.time();
 			}
 
-			if (token[0] == 'T_STRING' && typeof tokens[key-2] !== 'undefined' && Array.isArray(tokens[key-2]) && tokens[key-2][1] == "$this") {
+			if (token[0] === 'T_STRING' && typeof tokens[key-2] !== 'undefined' && Array.isArray(tokens[key-2]) && tokens[key-2][1] === "$this") {
 				if(!variables["$" + token[1]]) variables["$" + token[1]] = uniqid.time();
 			}
 
-			if (token[0] == 'T_STRING' && typeof tokens[key-2] !== 'undefined' && Array.isArray(tokens[key-2]) && tokens[key-2][1] == "function") {
+			if (token[0] === 'T_STRING' && typeof tokens[key-2] !== 'undefined' && Array.isArray(tokens[key-2]) && tokens[key-2][1] === "function") {
 				if(!functions[token[1]]) functions[token[1]] = token[1];
 			}
 
-			if (options_minify_remove_comments && (token[0] == 'T_COMMENT' || token[0] == 'T_DOC_COMMENT')) {
+			if (options_minify_remove_comments && (token[0] === 'T_COMMENT' || token[0] === 'T_DOC_COMMENT')) {
 				return;
 			}
 
@@ -124,10 +124,10 @@ function minifyPHP(synchronous, file_value, user_options) {
 		tokens.forEach((token, key) => {
 			if(Array.isArray(token))
 			{
-				if(token[0] == 'T_VARIABLE' && options_minify_replace_variables && options_excludes.indexOf(token[1]) < 0) {
+				if(token[0] === 'T_VARIABLE' && options_minify_replace_variables && options_excludes.indexOf(token[1]) < 0) {
 					new_source += "$" + variables[token[1]];
 				} 
-				else if(token[0] == 'T_WHITESPACE' && options_minify_remove_whitespace) {
+				else if(token[0] === 'T_WHITESPACE' && options_minify_remove_whitespace) {
 					if(typeof tokens[key-1] !== 'undefined' && typeof tokens[key+1] !== 'undefined' 
 						&& Array.isArray(tokens[key-1]) && Array.isArray(tokens[key+1]) 
 						&& tokens[key-1][1].match(/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/) 
@@ -136,7 +136,7 @@ function minifyPHP(synchronous, file_value, user_options) {
 						new_source += " ";
 					}
 				} 
-				else if(token[0] == 'T_STRING' && typeof tokens[key-2] !== 'undefined' && Array.isArray(tokens[key-2]) && tokens[key-2][1] == "$this" && options_minify_replace_variables && options_excludes.indexOf(token[1]) < 0) 
+				else if(token[0] === 'T_STRING' && typeof tokens[key-2] !== 'undefined' && Array.isArray(tokens[key-2]) && tokens[key-2][1] === "$this" && options_minify_replace_variables && options_excludes.indexOf(token[1]) < 0)
 				{
 					if(!functions[token[1]]){
 						new_source += variables["$" + token[1]];
@@ -144,16 +144,16 @@ function minifyPHP(synchronous, file_value, user_options) {
 						new_source += token[1];
 					}
 				}
-				else if(token[0] == 'T_CASE') {
+				else if(token[0] === 'T_CASE') {
 					new_source += token[1] + " ";
 				} 
-				else if(token[0] == 'T_OPEN_TAG') {
+				else if(token[0] === 'T_OPEN_TAG') {
 					new_source += "<?php ";
 				}
-				else if (token[0] == 'T_CLOSE_TAG') {
+				else if (token[0] === 'T_CLOSE_TAG') {
 					new_source += " ?>";
 				}
-				else if (token[0] == 'T_INLINE_HTML'){
+				else if (token[0] === 'T_INLINE_HTML'){
 					new_source += token[1].replace(/[\n\r]+/g, '').replace(/\s{2,10}/g, ' ');
 				}
 				else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,27 @@
 				"php-parser": "2.0.3",
 				"uniqid": "4.1.1"
 			},
-			"devDependencies": {}
+			"devDependencies": {
+				"@types/node": "^20.14.2",
+				"@types/uniqid": "^5.3.4"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "20.14.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+			"integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@types/uniqid": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/@types/uniqid/-/uniqid-5.3.4.tgz",
+			"integrity": "sha512-AgC+o3/8/QEHuU3w5w2jZ8auQtjSJ/s8G8RfEk9CYLogK1RGXqxhHH0wOEAu8uHXjvj8oh/dRtfgok4IHKxh/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/macaddress": {
 			"version": "0.2.9",
@@ -25,6 +45,13 @@
 			"resolved": "https://registry.npmjs.org/php-parser/-/php-parser-2.0.3.tgz",
 			"integrity": "sha512-7amJxHBomuTND8L0RzrlbegUqWaZSDQqTXa5MVyfnX2k9s9XaiusC6ne3mHKt3qLI9JYLDC2fAhAFQTUIey5VQ==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uniqid": {
 			"version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,39 @@
+{
+	"name": "uglify-php",
+	"version": "1.0.7",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "uglify-php",
+			"version": "1.0.7",
+			"license": "MIT",
+			"dependencies": {
+				"php-parser": "2.0.3",
+				"uniqid": "4.1.1"
+			},
+			"devDependencies": {}
+		},
+		"node_modules/macaddress": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.9.tgz",
+			"integrity": "sha512-k4F1JUof6cQXxNFzx3thLby4oJzXTXQueAOOts944Vqizn+Rjc2QNFenT9FJSLU1CH3PmrHRSyZs2E+Cqw+P2w==",
+			"license": "MIT"
+		},
+		"node_modules/php-parser": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/php-parser/-/php-parser-2.0.3.tgz",
+			"integrity": "sha512-7amJxHBomuTND8L0RzrlbegUqWaZSDQqTXa5MVyfnX2k9s9XaiusC6ne3mHKt3qLI9JYLDC2fAhAFQTUIey5VQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/uniqid": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+			"integrity": "sha512-jdaD46X0I0Q3NOlPEnZ+dfsiAE4L8mBg7UB7mpzc6JN2ERQd4TtpXXsTOO2RqwTFwPifyYv6zTMl/sODGfdcxA==",
+			"license": "MIT",
+			"dependencies": {
+				"macaddress": "^0.2.8"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
 		"uniqid": "4.1.1"
 	},
 	"devDependencies": {
-		"@types/node": "^20.14.2",
-		"@types/uniqid": "^5.3.4"
+		"@types/node": "^20"
 	},
 	"author": {
 		"name": "Flávio Reis",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,15 @@
 		"minimize"
 	],
 	"main": "lib/index.js",
+	"types": "types/index.d.ts",
 	"dependencies": {
 		"php-parser": "2.0.3",
 		"uniqid": "4.1.1"
 	},
-	"devDependencies": {},
+	"devDependencies": {
+		"@types/node": "^20.14.2",
+		"@types/uniqid": "^5.3.4"
+	},
 	"author": {
 		"name": "Flávio Reis",
 		"email": "flavioreis10@hotmail.com",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,10 +40,18 @@ declare namespace UglifyPHP {
         minify?: MinifyOptions,
         /**
          * A path to output to, if empty then no file will be written.
-         * Note that UglifyPHP considers a string of length 0 to be empty, as well as undefined.
+         *
+         * - The file will not be created if it does not already exist. To change this, set {@link create} to true.
+         *
+         * - Note that UglifyPHP considers a string of length 0 to be empty, as well as undefined.
          * The output can be retrieved from the return value of minify or minifySync.
          */
-        output?: string
+        output?: string,
+        /**
+         * Whether to create the output file if it does not exist. Does nothing if {@link output} is empty.
+         * Default is false.
+         */
+        create?: boolean,
     };
 
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,74 @@
+import { statSync, readFileSync, writeFileSync } from "node:fs";
+
+declare namespace UglifyPHP {
+
+    /**
+     * Options for the minifier
+     */
+    type MinifyOptions = {
+        /**
+         * True if variables should be renamed. Default is true.
+         */
+        replace_variables?: boolean,
+        /**
+         * True if whitespace should be removed. Default is true.
+         */
+        remove_whitespace?: boolean,
+        /**
+         * True if comments should be removed. Default is true.
+         */
+        remove_comments?: boolean,
+        /**
+         * True if HTML should be minified.
+         *
+         * @deprecated This value seems to be unused, but it is documented and reserved for future use.
+         */
+        minify_html?: boolean
+    };
+
+    /**
+     * Options for UglifyPHP
+     */
+    type Options = {
+        /**
+         * A list of variables names to exclude from obfuscation
+         */
+        excludes?: string[],
+        /**
+         * Options for the minifier
+         */
+        minify?: MinifyOptions,
+        /**
+         * A path to output to, if empty then no file will be written.
+         * Note that UglifyPHP considers a string of length 0 to be empty, as well as undefined.
+         * The output can be retrieved from the return value of minify or minifySync.
+         */
+        output?: string
+    };
+
+}
+
+declare interface UglifyPHP {
+
+    /**
+     * Uglifies PHP asynchronously.
+     * @param pathOrCode Either a file path or string containing PHP code.
+     * @param options Options to pass to the uglifier.
+     * @returns A promise that resolves with the uglified code. If {@link Options.output output} was specified in **options**,
+     * the data will also have been written to the file specified.
+     * @see minifySync
+     */
+    minify(pathOrCode: string, options: UglifyPHP.Options): Promise<string>;
+
+    /**
+     * Uglifies PHP synchronously. When providing code instead of a file path, {@link statSync} may still be called.
+     * Using a file path will always incur sync I/O via {@link readFileSync} and {@link writeFileSync}.
+     * @param pathOrCode Either a file path or string containing PHP code. Using a file path will incur sync I/O.
+     * @param options Options to pass to the uglifier.
+     * @returns The uglified code. If {@link Options.output output} was specified in **options**,
+     * the data will also have been written to the file specified.
+     * @see minify
+     */
+    minifySync(pathOrCode: string, options: UglifyPHP.Options): string;
+
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,6 +48,12 @@ declare namespace UglifyPHP {
 
 }
 
+/**
+ * UglifyPHP is a JavaScript minifier and simple obfuscator for PHP files.
+ * @see minify
+ * @see minifySync
+ * @see minifyCode
+ */
 declare interface UglifyPHP {
 
     /**
@@ -57,8 +63,9 @@ declare interface UglifyPHP {
      * @returns A promise that resolves with the uglified code. If {@link Options.output output} was specified in **options**,
      * the data will also have been written to the file specified.
      * @see minifySync
+     * @see minifyCode
      */
-    minify(pathOrCode: string, options: UglifyPHP.Options): Promise<string>;
+    minify(pathOrCode: string, options?: UglifyPHP.Options): Promise<string>;
 
     /**
      * Uglifies PHP synchronously. When providing code instead of a file path, {@link statSync} may still be called.
@@ -68,7 +75,28 @@ declare interface UglifyPHP {
      * @returns The uglified code. If {@link Options.output output} was specified in **options**,
      * the data will also have been written to the file specified.
      * @see minify
+     * @see minifyCode
      */
-    minifySync(pathOrCode: string, options: UglifyPHP.Options): string;
+    minifySync(pathOrCode: string, options?: UglifyPHP.Options): string;
+
+    /**
+     * Uglifies PHP code synchronously. This has an advantage over {@link minifySync} in that it can always skip a
+     * call to {@link statSync}, however this function cannot be used to minify by file path.
+     *
+     * An asynchronous variant of this method is not offered as the distinction between {@link minify} and
+     * {@link minifySync} arises from asynchronous I/O, not asynchronous parsing.
+     *
+     * @param code String containing PHP code.
+     * @param options Options to pass to the uglifier.
+     * @returns The uglified code. If {@link Options.output output} was specified in **options**, the data will also
+     * have been written to the file specified.
+     * @see minify
+     * @see minifySync
+     */
+    minifyCode(code: string, options?: UglifyPHP.Options): string;
 
 }
+
+declare const UglifyPHP: UglifyPHP;
+
+export = UglifyPHP;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,17 +41,15 @@ declare namespace UglifyPHP {
         /**
          * A path to output to, if empty then no file will be written.
          *
-         * - The file will not be created if it does not already exist. To change this, set {@link create} to true.
-         *
          * - Note that UglifyPHP considers a string of length 0 to be empty, as well as undefined.
          * The output can be retrieved from the return value of minify or minifySync.
          */
         output?: string,
         /**
-         * Whether to create the output file if it does not exist. Does nothing if {@link output} is empty.
-         * Default is false.
+         * If true, asserts that only file paths will be passed to minify & minifySync. This may be marginally faster.
+         * minifyCode will continue to accept source code strings.
          */
-        create?: boolean,
+        filesOnly?: boolean
     };
 
 }


### PR DESCRIPTION
- Generated missing package-lock.json, this is valuable for deterministic installs
- Normalized contract
  - Promise now always resolves with the output code, this is so that the typing doesn't need to have a special case. Side effects should be non-existent as dependents that are built with the assumption that the API will return a void promise should now quietly discard the output code.
    - Before
      ```js
      await UglifyPHP.minify("in.php", { output: "out.php" }); // void
      await UglifyPHP.minify("in.php"); // string
      ```
     - After
        ```js
        await UglifyPHP.minify("in.php", { output: "out.php" }); // string
        await UglifyPHP.minify("in.php"); // string
        ```
- Added types for compatibility with TypeScript
- Added documentation to types
- Applied lints
  - ``var`` -> ``let``, ``const``
  - ``==`` -> ``===`` (for string to string comparison, should be identical)
- Added method to API that accepts only source code; this means that using ``statSync`` to check if the input is a path is not required
- Added ``filesOnly`` option